### PR TITLE
Add a minor `persistent-scratch' mode

### DIFF
--- a/persistent-scratch.el
+++ b/persistent-scratch.el
@@ -154,7 +154,8 @@ representing the time of the last `persistent-scratch-new-backup' call."
           (let ((coding-system-for-write 'utf-8-unix))
             (write-region str nil tmp-file nil 0))
         (set-default-file-modes old-umask)))
-    (when (interactive-p)
+    (rename-file tmp-file actual-file t)
+    (when (called-interactively-p 'interactive)
       (message "Write file %s" actual-file)))
   (unless file
     (persistent-scratch--update-backup)

--- a/persistent-scratch.el
+++ b/persistent-scratch.el
@@ -154,7 +154,8 @@ representing the time of the last `persistent-scratch-new-backup' call."
           (let ((coding-system-for-write 'utf-8-unix))
             (write-region str nil tmp-file nil 0))
         (set-default-file-modes old-umask)))
-    (rename-file tmp-file actual-file t))
+    (when (interactive-p)
+      (message "Write file %s" actual-file)))
   (unless file
     (persistent-scratch--update-backup)
     (persistent-scratch--cleanup-backups)))
@@ -228,6 +229,21 @@ See `persistent-scratch-restore'."
        (message "Failed to restore scratch buffers: %S" err)
        nil))
     (setq persistent-scratch--auto-restored t)))
+
+(defvar persistent-scratch-mode-map
+  (let ((m (make-sparse-keymap)))
+    (define-key m [remap save-buffer] 'persistent-scratch-save)
+    (define-key m [remap write-file] 'persistent-scratch-save-to-file)
+    m)
+  "Keymap while persistent-scratch-minor-mode is active.")
+
+;;;###autoload
+(define-minor-mode persistent-scratch-mode
+  "Preserve the state of scratch buffers.
+
+Preserve the state of scratch buffers across Emacs sessions by saving the state
+to and restoring it from a file."
+  :lighter " PS")
 
 ;;;###autoload
 (define-minor-mode persistent-scratch-autosave-mode

--- a/persistent-scratch.el
+++ b/persistent-scratch.el
@@ -244,7 +244,11 @@ See `persistent-scratch-restore'."
 
 Preserve the state of scratch buffers across Emacs sessions by saving the state
 to and restoring it from a file."
-  :lighter " PS")
+  :lighter " PS"
+  (when persistent-scratch-mode
+    (unless (funcall persistent-scratch-scratch-buffer-p-function)
+      (setq  persistent-scratch-mode nil)
+      (user-error "This buffer isn't managed by `persistent-scratch' package. Mode isn't enabled"))))
 
 ;;;###autoload
 (define-minor-mode persistent-scratch-autosave-mode


### PR DESCRIPTION
This allow to add a mode map and remap `save-buffer' and `write-file'
to the persistent equivalents.  Also add a message when saving.

* persistent-scratch.el (persistent-scratch-save): add a message when called interactively,
                        (persistent-scratch-minor-mode) : new minor mode.