### PR TITLE
Keep current major mode if major mode not saved

### DIFF
--- a/persistent-scratch.el
+++ b/persistent-scratch.el
@@ -194,7 +194,9 @@ same name as a saved buffer, the contents of that buffer will be overwritten."
       (with-current-buffer (get-buffer-create (aref saved-buffer 0))
         (erase-buffer)
         (insert (aref saved-buffer 1))
-        (funcall (or (aref saved-buffer 3) #'fundamental-mode))
+        (let ((f (aref saved-buffer 3)))
+          (when f)
+          (funcall f))
         (let ((point-and-mark (aref saved-buffer 2)))
           (when point-and-mark
             (goto-char (car point-and-mark))


### PR DESCRIPTION
Hi Fanael,

Would it be better if we keep the current `major-mode` of `*scratch*` if we cannot found a valid saved `major-mode` in `persistent-scratch-save-file`?

I run into an issue that everytime I call `persistent-scratch-restore` manually, it will always apply a `major-mode`, from the saved one or  `fundamental-mode` instead. This makes my `*scratch*` buffer reset minor mode list. That means, minor modes I enabled for `*scratch*` buffer only are turned off.

Would it be better if `persistent-scratch` does nothing when I choose to not save the `major-mode` of `*scratch*` buffer?

Admire your work, thanks!.